### PR TITLE
Adds `x-substrate-request-id` header 

### DIFF
--- a/substrate/_client.py
+++ b/substrate/_client.py
@@ -2,6 +2,7 @@ import logging
 import platform
 from typing import Any, Dict, Union, Optional
 from typing_extensions import Literal
+from .core.id_generator import IDGenerator
 
 import httpx
 import distro
@@ -169,6 +170,7 @@ class APIClient:
             "Content-Type": "application/json",
             "User-Agent": self.user_agent,
             "X-Substrate-Backend": self._backend,
+            "X-Substrate-Request-Id": IDGenerator.random_string(32),
             **self.platform_headers,
             **self.auth_headers,
             **self._additional_headers,

--- a/substrate/core/id_generator.py
+++ b/substrate/core/id_generator.py
@@ -10,17 +10,23 @@ class IDGenerator:
     _generators: Dict[str, "IDGenerator"] = {}
     _lock = Lock()
 
-    def __init__(self, prefix: str):
+    def __init__(self, prefix: str, length: int = 8):
         self.prefix = prefix
         self.n = 1
+        self.length = length
 
     def get_next_id(self):
         with IDGenerator._lock:
-            alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
-            random_string = "".join(random.choices(alphabet, k=8))
+            random_string = IDGenerator.random_string(self.length)
             next_id = f"{self.prefix}{self.n}_{random_string}"
             self.n += 1
             return next_id
+
+    @staticmethod
+    def random_string(length: int) -> str:
+        alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+        random_string = "".join(random.choices(alphabet, k=length))
+        return random_string
 
     @staticmethod
     def get_instance(class_name: str) -> "IDGenerator":


### PR DESCRIPTION
Adds the `x-substrate-request-id` header into requests made from the Python SDK client to support request tracing.

I re-used our `random_string` function here to mirror how we're generating these in the TypeScript SDK too.

<img width="1148" alt="Screenshot 2024-05-20 at 11 00 24 AM" src="https://github.com/SubstrateLabs/substrate-python/assets/179645/14bcfc35-e5b4-40f7-9a65-6b207f630a74">
Example headers dict printed out from a breakpoint in the client

Also see:
* https://github.com/SubstrateLabs/substrate-typescript/pull/79
* https://github.com/SubstrateLabs/substrate/issues/961
