### PR TITLE
Implements `_depends` kwarg for setting explicit edges in graph

### DIFF
--- a/examples/explicit_edges.py
+++ b/examples/explicit_edges.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+# add parent dir to sys.path to make 'substrate' importable
+parent_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(parent_dir))
+
+api_key = os.environ.get("SUBSTRATE_API_KEY")
+if api_key is None:
+    raise EnvironmentError("No SUBSTRATE_API_KEY set")
+
+from substrate import RunPython, Substrate
+
+substrate = Substrate(api_key=api_key, timeout=60 * 5)
+
+def print_time():
+    import time
+    return time.time()
+
+a = RunPython(function=print_time)
+a.id = "a"
+
+b = RunPython(function=print_time, _depends=[a])
+b.id = "b"
+
+c = RunPython(function=print_time, _depends=[a, b])
+c.id = "c"
+
+res = substrate.run(a, b, c)
+print(res.json)

--- a/substrate/core/coregraph.py
+++ b/substrate/core/coregraph.py
@@ -28,6 +28,10 @@ class CoreGraph:
     def futures(self) -> List[BaseFuture]:
         raise NotImplementedError
 
+    def add_edge(self, u_node: CoreNode, v_node: CoreNode, **kwargs) -> "CoreGraph":
+        self.DAG.add_edge(u_node, v_node, **kwargs)
+        return self
+
     def add_node(self, node: CoreNode) -> "CoreGraph":
         self.DAG = nx.compose(self.DAG, node.SG)
         return self

--- a/substrate/run_python.py
+++ b/substrate/run_python.py
@@ -14,6 +14,10 @@ class RunPython(CoreNode[RunPythonOut]):
         kwargs: Dict[str, Any] = {},
         pip_install: Optional[List[str]] = None,
         hide: bool = False,
+        _cache_age: Optional[int] = None,
+        _cache_keys: Optional[List[str]] = None,
+        _max_retries: Optional[int] = None,
+        _depends: List[CoreNode] = [],
     ):
         """
         Args:
@@ -42,6 +46,10 @@ class RunPython(CoreNode[RunPythonOut]):
             hide=hide,
             python_version=python_version,
             out_type=RunPythonOut,
+            _cache_age=_cache_age,
+            _cache_keys=_cache_keys,
+            _max_retries=_max_retries,
+            _depends=_depends,
         )
         self.node = "RunPython"
 

--- a/substrate/substrate.py
+++ b/substrate/substrate.py
@@ -97,5 +97,7 @@ class Substrate:
         graph = Graph()
         for node in all_nodes:
             graph.add_node(node)
+            for depend_node in node._depends:
+                graph.add_edge(depend_node, node)
         graph_serialized = graph.to_dict()
         return graph_serialized

--- a/tests/python-3-9/tests/test_substrate.py
+++ b/tests/python-3-9/tests/test_substrate.py
@@ -36,3 +36,18 @@ class TestSubstrate:
         node_ids = sorted([d["id"] for d in result["nodes"]])
         assert node_ids == [a.id, b.id, c.id]
         assert len(result["futures"]) == 2
+
+    def test_serialize_with_depends_list(self):
+        a = CoreNode(x="x", out_type=MockOutput)
+        a.id = "a"
+        b = CoreNode(x="x", out_type=MockOutput, _depends=[a])
+        b.id = "b"
+        c = CoreNode(x="x", out_type=MockOutput, _depends=[a, b])
+        c.id = "c"
+
+        # when nodes are connected via _depends, `edges` should be populated correctly
+        edges = Substrate.serialize(a, b, c).get("edges")
+        assert len(edges) == 3
+        assert ["a", "b", {}] in edges
+        assert ["a", "c", {}] in edges
+        assert ["b", "c", {}] in edges


### PR DESCRIPTION
When you would like to control the ordering of nodes in the graph, but do not want to connect nodes via future input args we're implementing the `_depends` option on `CoreNode` to specify what nodes a node depends on.

What this looks like:

```python
a = FooNode(x=1)
b = FooNode(x=2, _depends=[a])
c = FooNode(x=3, _depends=[a, b])
```

When we serialize the graph we'll set the `edges` key in the API JSON that we'll use on the server when scheduling nodes so that they are run in order: `a, b, c`